### PR TITLE
fix VITA_RenderPresent

### DIFF
--- a/src/render/vita/SDL_render_vita.c
+++ b/src/render/vita/SDL_render_vita.c
@@ -579,6 +579,7 @@ VITA_RenderPresent(SDL_Renderer *renderer)
 	vita2d_end_drawing();
 	vita2d_swap_buffers();
 
+	data->displayListAvail = SDL_FALSE;
 }
 
 static void


### PR DESCRIPTION
"data->displayListAvail" was not set to false after "VITA_RenderPresent", preventing "StartDrawing" (vita2d_start_drawing) to be called after "SDL_RenderPresent".
