### PR TITLE
Removed: psp2/moduleinfo.h

### DIFF
--- a/src/render/vita/SDL_render_vita.c
+++ b/src/render/vita/SDL_render_vita.c
@@ -28,7 +28,6 @@
 #include <psp2/types.h>
 #include <psp2/display.h>
 #include <psp2/gxm.h>
-#include <psp2/moduleinfo.h>
 #include <psp2/kernel/processmgr.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This include file was removed from vita-headers:
https://github.com/vitasdk/vita-headers/issues/5

Removing the reference from SDL_render_vita.c allows SDL-Vita to build after this change.